### PR TITLE
Changed to use UnityWebRequest from the deprecated WWW

### DIFF
--- a/Assets/Unimgpicker/Samples/PickerController.cs
+++ b/Assets/Unimgpicker/Samples/PickerController.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine.UI;
+using UnityEngine.Networking;
 
 namespace Kakera
 {
@@ -34,10 +34,10 @@ namespace Kakera
         private IEnumerator LoadImage(string path, MeshRenderer output)
         {
             var url = "file://" + path;
-            var www = new WWW(url);
-            yield return www;
+            var unityWebRequestTexture = UnityWebRequestTexture.GetTexture(url);
+            yield return unityWebRequestTexture.SendWebRequest();
 
-            var texture = www.texture;
+            var texture = ((DownloadHandlerTexture)unityWebRequestTexture.downloadHandler).texture;
             if (texture == null)
             {
                 Debug.LogError("Failed to load texture url:" + url);


### PR DESCRIPTION
```
Assets/Unimgpicker/Samples/PickerController.cs(37,27): warning CS0618: 'WWW' is obsolete: 'Use UnityWebRequest, a fully featured replacement which is more efficient and has additional features'
```
Changed to use UnityWebRequest from the deprecated WWW.

https://forum.unity.com/threads/www-marked-as-obsolete.606763/
https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest.html
