### PR TITLE
Add clang-format

### DIFF
--- a/.ci/run-format
+++ b/.ci/run-format
@@ -1,4 +1,8 @@
 #!/bin/bash
 DIR=$1
 
+# Permission error workaround on GitHub Actions
+sudo chown user:user -R $DIR
+git config --global --add safe.directory /build
+
 find $DIR -name "*.cs" | xargs clang-format -i

--- a/.ci/run-format
+++ b/.ci/run-format
@@ -1,0 +1,4 @@
+#!/bin/bash
+DIR=$1
+
+find $DIR -name "*.cs" | xargs clang-format -i

--- a/.ci/run-lint
+++ b/.ci/run-lint
@@ -1,0 +1,7 @@
+#!/bin/bash
+DIR=$1
+
+if [[ `git status --porcelain` ]]; then
+  git --no-pager diff $DIR
+  exit 1
+fi

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Microsoft
+
+NamespaceIndentation: All
+ColumnLimit: 256
+
+DeriveLineEnding: false
+UseCRLF: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.cs]
-indent_style = space
-indent_size = 4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,7 +1,6 @@
 name: Linter
 
 on:
-  push:
   pull_request:
     branches: [master, main]
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,24 @@
+name: Linter
+
+on:
+  push:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_CSHARP: true
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,9 +15,6 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_CSHARP: true
-          DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          docker pull thedoritos/unimgpicker:latest
+          docker run --rm -v $PWD:/build -w /build thedoritos/unimgpicker make lint

--- a/Assets/Unimgpicker/Samples/PickerController.cs
+++ b/Assets/Unimgpicker/Samples/PickerController.cs
@@ -12,14 +12,12 @@ namespace Kakera
         [SerializeField]
         private MeshRenderer imageRenderer;
 
-        private int[] sizes = {1024, 256, 16};
+        private int[] sizes = { 1024, 256, 16 };
 
         void Awake()
         {
             imagePicker.Completed += (string path) =>
-            {
-                StartCoroutine(LoadImage(path, imageRenderer));
-            };
+            { StartCoroutine(LoadImage(path, imageRenderer)); };
         }
 
         public void OnPressShowPicker()

--- a/Assets/Unimgpicker/Scripts/Picker_editor.cs
+++ b/Assets/Unimgpicker/Scripts/Picker_editor.cs
@@ -6,24 +6,25 @@ using System.IO;
 
 namespace Kakera
 {
-	internal class Picker_editor : IPicker
-	{
-		public void Show(string title, string outputFileName)
-		{
-			var path = EditorUtility.OpenFilePanel(title, "","png");
-			if (path.Length != 0) {
-				string destination = Application.persistentDataPath + "/" + outputFileName;
-				if (File.Exists(destination))
-					File.Delete(destination);
-				File.Copy(path, destination);
-				Debug.Log ("PickerOSX:" + destination);
-				var receiver = GameObject.Find("Unimgpicker");
-				if (receiver != null)
-				{
-					receiver.SendMessage("OnComplete", Application.persistentDataPath + "/" + outputFileName);
-				}
-			}
-		}
-	}
+    internal class Picker_editor : IPicker
+    {
+        public void Show(string title, string outputFileName)
+        {
+            var path = EditorUtility.OpenFilePanel(title, "", "png");
+            if (path.Length != 0)
+            {
+                string destination = Application.persistentDataPath + "/" + outputFileName;
+                if (File.Exists(destination))
+                    File.Delete(destination);
+                File.Copy(path, destination);
+                Debug.Log("PickerOSX:" + destination);
+                var receiver = GameObject.Find("Unimgpicker");
+                if (receiver != null)
+                {
+                    receiver.SendMessage("OnComplete", Application.persistentDataPath + "/" + outputFileName);
+                }
+            }
+        }
+    }
 }
 #endif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y dotnet6 sudo make
+RUN apt-get update && apt-get install -y clang-format sudo make
 
 RUN adduser --disabled-password --gecos '' user
 RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y dotnet6 sudo make
+
+RUN adduser --disabled-password --gecos '' user
+RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+USER user
+WORKDIR /home/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y clang-format sudo make
+RUN apt-get update && apt-get install -y clang-format sudo make git
 
 RUN adduser --disabled-password --gecos '' user
 RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 format:
-	dotnet format Assembly-CSharp.csproj
+	find ./Assets -name "*.cs" | xargs clang-format -i
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+format:
+	dotnet format Assembly-CSharp.csproj
+
+.PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 format:
-	find ./Assets -name "*.cs" | xargs clang-format -i
+	${CURDIR}/.ci/run-format ${CURDIR}/Assets
 
-.PHONY: format
+lint: format
+	${CURDIR}/.ci/run-lint ${CURDIR}/Assets
+
+.PHONY: format lint

--- a/README.md
+++ b/README.md
@@ -78,8 +78,20 @@ The code is developed on following environments. Note that these are NOT minimum
 | iOS | 13.3 | Xcode 11.6 |
 | Android | 10.0 (API 29) | Android Studio 4.0.1 |
 
+## For Developers
 
-## Building Unimgpicker by Self
+### Running formatter
+
+```sh
+# If dotnet6 is installed.
+$ make format
+
+# If docker is installed.
+$ docker build -t dotnet .
+$ docker run --rm -v $PWD:/build -w /build dotnet make format
+```
+
+### Building Unimgpicker by Self
 
 This repository contains Android project to develop Unimgpicker.
 You can make changes to the code and build your own jar.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The code is developed on following environments. Note that these are NOT minimum
 $ make format
 
 # If docker is installed.
-$ docker build -t dotnet .
-$ docker run --rm -v $PWD:/build -w /build dotnet make format
+$ docker build -t unimgpicker .
+$ docker run --rm -v $PWD:/build -w /build unimgpicker make format
 ```
 
 ### Building Unimgpicker by Self


### PR DESCRIPTION
## Summary
This is a test to add linter for this project.

## Why
To provide the preferred coding style for the project.

## TODO
- Run linter on local environment
- Run linter on pull requests

## The Whole Story
I tried several formatters in this PR and ended up with clang-format.

### dotnet-format
A formatter packaged within dotnet SDK seemed good for the first choice.
It provides a couple of commands to format code, and `dotnet format` was what I needed.
However, the command requires `.sln` or `.csproj` file as the argument, and here comes a problem because `.csproj` file is auto-generated by Unity editor.

https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-format

### Super-Linter (as a wrapper of dotnet-format)
A easy to use formatter designed to be used on GitHub Actions.
It contains linters or formatters for many languages as well as dotnet-format for C#.
However, the command which is executed by Super-Linter is `dotnet-format` w/ `--folder` option. Unfortunately, It only checks whitespaces.

https://github.com/github/super-linter

### clang-format
A formatter for C++ and other languages.
It can check whitespaces, line breaks and etc., w/o specifying a solution file.
While it can be configured by a config file named `.clang-format`, following Microsoft's base configuration fits with the current code format in unimgpicker with little customization.

https://clang.llvm.org/docs/ClangFormat.html

## FIXME
There is a workaround on a14411c to avoid following errors on GitHub actions.

```
clang-format error:unable to make temporary file: /build/Assets/Unimgpicker/Samples/PickerController.cs-910fdf96
clang-format error:unable to make temporary file: /build/Assets/Unimgpicker/Scripts/Picker_editor.cs-e6f3253c
```

While the workaround works, changing ownership of the directories nor git config seem to not a relevant solution.
