### PR TITLE
Add minimum package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.kakeragames.unimgpicker",
+  "version": "2.0.0",
+  "description": "Image picker for Unity iOS/Android",
+  "displayName": "Unimgpicker",
+  "licensesUrl": "https://raw.githubusercontent.com/thedoritos/unimgpicker/main/LICENSE.txt"
+}


### PR DESCRIPTION
## Summary

This PR adds a minimum `package.json` file to make Unimgpicker importable via Package Manager of Unity.

## Changes

- Added `package.json`
  - With minimum properties documented in the [official doc](https://docs.unity3d.com/Manual/upm-manifestPkg.html)